### PR TITLE
Enhance README with GHDL and GTKWave installation steps for macOS

### DIFF
--- a/ghdl/README.md
+++ b/ghdl/README.md
@@ -37,12 +37,24 @@ $ sudo make install
 > [Use Homebrew to install GTKWave](https://formulae.brew.sh/cask/gtkwave)\
 > [Compatibility issue](https://github.com/gtkwave/gtkwave/issues/250)\
 > [GTKWave on Flathub](https://flathub.org/apps/io.github.gtkwave.GTKWave)
+### Using Brew to install GHDL and GTKWave
+```
+brew install --cask ghdl
+brew install --cask gtkwave
+```
+If this doesn't work on newer versions of macOS, try:
+```
+brew list | grep -i gtk | xargs brew uninstall ; brew install yanjiew1/gtkwave/gtkwave
+```
+### Using Flatpak for GTKWave
 ```
 flatpak install flathub io.github.gtkwave.GTKWave
 flatpak run io.github.gtkwave.GTKWave
 ```
 > [Fliplot](https://github.com/raczben/fliplot) is an alternative to GTKWave, implemented in HTML, JavaScript, and Python\
 > [HDL Containers](https://hdl.github.io/containers/)
+
+**(Skip to GHDL Quick Start Guide step if you installed GHDL via Brew)**
 
 * Open a Terminal
 ```sh


### PR DESCRIPTION
Added installation instructions for GHDL and GTKWave using Brew. Shows how to install GHDL and GTKWave through brew. Shows a fix for GTKWave on newer versions of macOS using brew.